### PR TITLE
fix(CMakeLists.txt): run ament_auto_packages() for ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1078,3 +1078,7 @@ install (DIRECTORY ${_glog_BINARY_CMake_DATADIR}
 
 install (EXPORT glog-targets NAMESPACE glog:: DESTINATION
   ${_glog_CMake_INSTALLDIR})
+
+# installation for ROS 2
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_package()


### PR DESCRIPTION
This PR adds ament_auto_packages() command in the CMakeLists.txt so that following error will disappear when running `source install/setup.bash` in the colcon workspace.