### PR TITLE
Change minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1078,3 +1078,7 @@ install (DIRECTORY ${_glog_BINARY_CMake_DATADIR}
 
 install (EXPORT glog-targets NAMESPACE glog:: DESTINATION
   ${_glog_CMake_INSTALLDIR})
+
+# installation for ROS 2
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_package()

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>glog</name>
+  <version>0.1.0</version>
+  <description>The TIERIV glog ros vendor package</description>
+
+  <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
CMake 4.0 Removes compatibility with CMake < 3.5. The patch changes the minimum CMake policy version from 3.2 to 3.5 to enable CMake 4 compatibility.